### PR TITLE
[REFACTOR] Set text hight of button to 1.0 #70

### DIFF
--- a/lib/common/component/custom_outlined_button.dart
+++ b/lib/common/component/custom_outlined_button.dart
@@ -39,6 +39,7 @@ class CustomOutlinedButton extends StatelessWidget {
         style: defaultFontStyleBlack.copyWith(
           fontSize: 14.0.sp,
           fontWeight: FontWeight.w500,
+          height: 1.0,
           color: isSelected ? Colors.white : Colors.black,
         ),
       ),


### PR DESCRIPTION
- custom_outlined_button.dart : set height of text inside button to 1.0 for layout.